### PR TITLE
Add custom fixtures for suite init/cleanup and function init/cleanup

### DIFF
--- a/doc/ctest_user_manual.md
+++ b/doc/ctest_user_manual.md
@@ -108,12 +108,16 @@ These functions shall get called by the test runner before the `CTEST_SUITE_INIT
 
 Example usages:
 
+- No custom fixtures
+
 ```c
 CTEST_SUITE_INITIALIZE(suite_init)
 {
     /* Some init code */
 }
 ```
+
+- Using custom fixtures
 
 ```c
 static void my_suite_initialize_fixture(void)
@@ -146,12 +150,16 @@ These functions shall get called by the test runner after the `CTEST_SUITE_CLEAN
 
 Example usages:
 
+- No custom fixtures
+
 ```c
 CTEST_SUITE_CLEANUP(suite_cleanup)
 {
     /* Free resources allocated in CTEST_SUITE_INITIALIZE */
 }
 ```
+
+- Using custom fixtures
 
 ```c
 static void my_suite_cleanup_fixture(void)
@@ -184,12 +192,16 @@ These functions shall get called by the test runner before the `CTEST_FUNCTION_I
 
 Example usages:
 
+- No custom fixtures
+
 ```c
 CTEST_FUNCTION_INITIALIZE(function_initialize)
 {
     /* Initialize specific things for each test function */
 }
 ```
+
+- Using custom fixtures
 
 ```c
 static void my_function_initialize_fixture(void)
@@ -222,12 +234,16 @@ These functions shall get called by the test runner after the `CTEST_FUNCTION_CL
 
 Example usages:
 
+- No custom fixtures
+
 ```c
 CTEST_FUNCTION_CLEANUP(function_cleanup)
 {
     /* Free resources allocated in CTEST_FUNCTION_INITIALIZE */
 }
 ```
+
+- Using custom fixtures
 
 ```c
 static void my_function_cleanup_fixture(void)

--- a/doc/ctest_user_manual.md
+++ b/doc/ctest_user_manual.md
@@ -94,7 +94,34 @@ When this is used, the check for allocations that have not been freed is checked
 This special fixture is executed before all the tests in the test suite. All resources allocated in `CTEST_SUITE_INITIALIZE` should be freed in `CTEST_SUITE_CLEANUP`.
 
 ```c
-CTEST_SUITE_INITIALIZE()
+#define CTEST_SUITE_INITIALIZE(funcName, ...) \
+    ...
+```
+
+The `...` argument is a list of 0 or more function names with the signature:
+
+```c
+void function(void)
+```
+
+These functions shall get called by the test runner before the `CTEST_SUITE_INITIALIZE` code is executed.
+
+Example usages:
+
+```c
+CTEST_SUITE_INITIALIZE(suite_init)
+{
+    /* Some init code */
+}
+```
+
+```c
+static void my_suite_initialize_fixture(void)
+{
+    // nothing interesting here
+}
+
+CTEST_SUITE_INITIALIZE(suite_init, my_suite_initialize_fixture)
 {
     /* Some init code */
 }
@@ -105,7 +132,34 @@ CTEST_SUITE_INITIALIZE()
 This special fixture is executed after all the tests in the test suite.
 
 ```c
-CTEST_SUITE_CLEANUP()
+#define CTEST_SUITE_CLEANUP(funcName, ...) \
+    ...
+```
+
+The `...` argument is a list of 0 or more function names with the signature:
+
+```c
+void function(void)
+```
+
+These functions shall get called by the test runner after the `CTEST_SUITE_CLEANUP` code is executed.
+
+Example usages:
+
+```c
+CTEST_SUITE_CLEANUP(suite_cleanup)
+{
+    /* Free resources allocated in CTEST_SUITE_INITIALIZE */
+}
+```
+
+```c
+static void my_suite_cleanup_fixture(void)
+{
+    // nothing interesting here
+}
+
+CTEST_SUITE_CLEANUP(suite_cleanup, my_suite_cleanup_fixture)
 {
     /* Free resources allocated in CTEST_SUITE_INITIALIZE */
 }
@@ -116,7 +170,34 @@ CTEST_SUITE_CLEANUP()
 This special fixture is executed before calling each test function in the test suite. All resources allocated in `CTEST_FUNCTION_INITIALIZE` should be freed in `CTEST_FUNCTION_CLEANUP`.
 
 ```c
-CTEST_FUNCTION_INITIALIZE()
+#define CTEST_FUNCTION_INITIALIZE(funcName, ...) \
+    ...
+```
+
+The `...` argument is a list of 0 or more function names with the signature:
+
+```c
+void function(void)
+```
+
+These functions shall get called by the test runner before the `CTEST_FUNCTION_INITIALIZE` code is executed.
+
+Example usages:
+
+```c
+CTEST_FUNCTION_INITIALIZE(function_initialize)
+{
+    /* Initialize specific things for each test function */
+}
+```
+
+```c
+static void my_function_initialize_fixture(void)
+{
+    // nothing interesting here
+}
+
+CTEST_FUNCTION_INITIALIZE(function_initialize, my_function_initialize_fixture)
 {
     /* Initialize specific things for each test function */
 }
@@ -127,7 +208,34 @@ CTEST_FUNCTION_INITIALIZE()
 This special fixture is executed after each test in the test suite.
 
 ```c
-CTEST_FUNCTION_CLEANUP()
+#define CTEST_FUNCTION_CLEANUP(funcName, ...) \
+    ...
+```
+
+The `...` argument is a list of 0 or more function names with the signature:
+
+```c
+void function(void)
+```
+
+These functions shall get called by the test runner after the `CTEST_FUNCTION_CLEANUP` code is executed.
+
+Example usages:
+
+```c
+CTEST_FUNCTION_CLEANUP(function_cleanup)
+{
+    /* Free resources allocated in CTEST_FUNCTION_INITIALIZE */
+}
+```
+
+```c
+static void my_function_cleanup_fixture(void)
+{
+    // nothing interesting here
+}
+
+CTEST_FUNCTION_CLEANUP(function_cleanup, my_function_cleanup_fixture)
 {
     /* Free resources allocated in CTEST_FUNCTION_INITIALIZE */
 }

--- a/inc/ctest.h
+++ b/inc/ctest.h
@@ -138,33 +138,60 @@ extern jmp_buf g_ExceptionJump;
     CTEST_CUSTOM_TEST_FUNCTION_CODE(funcName) \
     static void funcName(void)
 
-#define CTEST_SUITE_INITIALIZE(funcName) \
-    static void TestSuiteInitialize(void); \
-    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) = \
-{ TestSuiteInitialize, "TestSuiteInitialize", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_SUITE_INITIALIZE }; \
-    CTEST_CUSTOM_TEST_SUITE_INITIALIZE_CODE(funcName) \
-    static void TestSuiteInitialize(void)
+#define CTEST_CALL_FIXTURE(A) \
+    A();
 
-#define CTEST_SUITE_CLEANUP(funcName) \
-    static void TestSuiteCleanup(void); \
-    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) = \
-{ &TestSuiteCleanup, "TestSuiteCleanup", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_SUITE_CLEANUP }; \
-    CTEST_CUSTOM_TEST_SUITE_CLEANUP_CODE(funcName) \
-    static void TestSuiteCleanup(void)
+#define CTEST_SUITE_INITIALIZE(funcName, ...)                                                                                                           \
+    static void TestSuiteInitialize(void);                                                                                                              \
+    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) =                                                               \
+{ TestSuiteInitialize, "TestSuiteInitialize", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_SUITE_INITIALIZE };        \
+    CTEST_CUSTOM_TEST_SUITE_INITIALIZE_CODE(funcName)                                                                                                   \
+    static void TestSuiteInitialize_user(void);                                                                                                         \
+    static void TestSuiteInitialize(void)                                                                                                               \
+    {                                                                                                                                                   \
+        MU_IF(MU_COUNT_ARG(__VA_ARGS__),MU_FOR_EACH_1(CTEST_CALL_FIXTURE, __VA_ARGS__),)                                                                \
+        TestSuiteInitialize_user();                                                                                                                     \
+    }                                                                                                                                                   \
+    static void TestSuiteInitialize_user(void)
 
-#define CTEST_FUNCTION_INITIALIZE(funcName) \
-    static void TestFunctionInitialize(void); \
-    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) = \
-{ TestFunctionInitialize, "TestFunctionInitialize", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_FUNCTION_INITIALIZE }; \
-    CTEST_CUSTOM_TEST_FUNCTION_INITIALIZE_CODE(funcName) \
-    static void TestFunctionInitialize(void)
+#define CTEST_SUITE_CLEANUP(funcName, ...)                                                                                                              \
+    static void TestSuiteCleanup(void);                                                                                                                 \
+    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) =                                                               \
+{ &TestSuiteCleanup, "TestSuiteCleanup", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_SUITE_CLEANUP };                \
+    CTEST_CUSTOM_TEST_SUITE_CLEANUP_CODE(funcName)                                                                                                      \
+    static void TestSuiteCleanup_user(void);                                                                                                            \
+    static void TestSuiteCleanup(void)                                                                                                                  \
+    {                                                                                                                                                   \
+        TestSuiteCleanup_user();                                                                                                                        \
+        MU_IF(MU_COUNT_ARG(__VA_ARGS__),MU_FOR_EACH_1(CTEST_CALL_FIXTURE, __VA_ARGS__),)                                                                \
+    }                                                                                                                                                   \
+    static void TestSuiteCleanup_user(void)
 
-#define CTEST_FUNCTION_CLEANUP(funcName) \
-    static void TestFunctionCleanup(void); \
-    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) = \
-{ &TestFunctionCleanup, "TestFunctionCleanup", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_FUNCTION_CLEANUP }; \
-    CTEST_CUSTOM_TEST_FUNCTION_CLEANUP_CODE(funcName) \
-    static void TestFunctionCleanup(void)
+#define CTEST_FUNCTION_INITIALIZE(funcName, ...)                                                                                                            \
+    static void TestFunctionInitialize(void);                                                                                                               \
+    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) =                                                                   \
+{ TestFunctionInitialize, "TestFunctionInitialize", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_FUNCTION_INITIALIZE };   \
+    CTEST_CUSTOM_TEST_FUNCTION_INITIALIZE_CODE(funcName)                                                                                                    \
+    static void TestFunctionInitialize_user(void);                                                                                                          \
+    static void TestFunctionInitialize(void)                                                                                                                \
+    {                                                                                                                                                       \
+        MU_IF(MU_COUNT_ARG(__VA_ARGS__),MU_FOR_EACH_1(CTEST_CALL_FIXTURE, __VA_ARGS__),)                                                                    \
+        TestFunctionInitialize_user();                                                                                                                      \
+    }                                                                                                                                                       \
+    static void TestFunctionInitialize_user(void)
+
+#define CTEST_FUNCTION_CLEANUP(funcName, ...)                                                                                                               \
+    static void TestFunctionCleanup(void);                                                                                                                  \
+    static const TEST_FUNCTION_DATA MU_C2(TestFunctionData, MU_C1(MU_INC(__COUNTER__))) =                                                                   \
+{ &TestFunctionCleanup, "TestFunctionCleanup", &MU_C2(TestFunctionData, MU_C1(MU_DEC(MU_DEC(__COUNTER__)))), NULL, CTEST_TEST_FUNCTION_CLEANUP };           \
+    CTEST_CUSTOM_TEST_FUNCTION_CLEANUP_CODE(funcName)                                                                                                       \
+    static void TestFunctionCleanup_user(void);                                                                                                             \
+    static void TestFunctionCleanup(void)                                                                                                                   \
+    {                                                                                                                                                       \
+        TestFunctionCleanup_user();                                                                                                                         \
+        MU_IF(MU_COUNT_ARG(__VA_ARGS__),MU_FOR_EACH_1(CTEST_CALL_FIXTURE, __VA_ARGS__),)                                                                    \
+    }                                                                                                                                                       \
+    static void TestFunctionCleanup_user(void)
 
 #define CTEST_END_TEST_SUITE(testSuiteName) \
     C_LINKAGE_PREFIX const TEST_FUNCTION_DATA TestListHead_##testSuiteName = { NULL, NULL, &MU_C2(TestFunctionData, MU_C1(MU_DEC(__COUNTER__))), NULL, CTEST_END_SUITE }; \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,4 @@
 
 add_subdirectory(ctest_ut)
 add_subdirectory(ctest_macro_hooks_ut)
+add_subdirectory(ctest_custom_fixtures_ut)

--- a/tests/ctest_custom_fixtures_ut/CMakeLists.txt
+++ b/tests/ctest_custom_fixtures_ut/CMakeLists.txt
@@ -23,5 +23,5 @@ set_target_properties(ctest_custom_fixtures_ut
 target_link_libraries(ctest_custom_fixtures_ut ctest)
 
 if(${run_unittests})
-	add_test(NAME ctest_custom_fixtures_ut COMMAND ctest_custom_fixtures_ut)
+    add_test(NAME ctest_custom_fixtures_ut COMMAND ctest_custom_fixtures_ut)
 endif()

--- a/tests/ctest_custom_fixtures_ut/CMakeLists.txt
+++ b/tests/ctest_custom_fixtures_ut/CMakeLists.txt
@@ -1,0 +1,27 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+set(ctest_custom_fixtures_ut_c_files
+    ctest_one_custom_fixture_ut.c
+    ctest_multiple_custom_fixtures_ut.c
+    main.c
+)
+
+set(ctest_custom_fixtures_ut_h_files
+    ctest_one_custom_fixture_ut.h
+    ctest_multiple_custom_fixtures_ut.h
+)
+
+include_directories(${CTEST_INC_FOLDER})
+
+add_executable(ctest_custom_fixtures_ut ${ctest_custom_fixtures_ut_c_files} ${ctest_custom_fixtures_ut_h_files})
+
+set_target_properties(ctest_custom_fixtures_ut
+               PROPERTIES
+               FOLDER "tests/ctest")
+
+target_link_libraries(ctest_custom_fixtures_ut ctest)
+
+if(${run_unittests})
+	add_test(NAME ctest_custom_fixtures_ut COMMAND ctest_custom_fixtures_ut)
+endif()

--- a/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.c
+++ b/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.c
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "macro_utils/macro_utils.h"
+
+#include "ctest.h"
+
+CTEST_BEGIN_TEST_SUITE(ctest_multiple_custom_fixtures_ut)
+
+#define FIXTURE_CALL_VALUES \
+    FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1, \
+    FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2, \
+    FIXTURE_CALL_USER_SUITE_INITIALIZE, \
+    FIXTURE_CALL_CUSTOM_SUITE_CLEANUP_1, \
+    FIXTURE_CALL_CUSTOM_SUITE_CLEANUP_2, \
+    FIXTURE_CALL_USER_SUITE_CLEANUP, \
+    FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, \
+    FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2, \
+    FIXTURE_CALL_USER_FUNCTION_INITIALIZE, \
+    FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1, \
+    FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2, \
+    FIXTURE_CALL_USER_FUNCTION_CLEANUP
+
+MU_DEFINE_ENUM(FIXTURE_CALL_TYPE, FIXTURE_CALL_VALUES)
+
+MU_DEFINE_ENUM_STRINGS(FIXTURE_CALL_TYPE, FIXTURE_CALL_VALUES)
+CTEST_DEFINE_ENUM_TYPE(FIXTURE_CALL_TYPE, FIXTURE_CALL_VALUES)
+
+static FIXTURE_CALL_TYPE actual_calls[100];
+static int actual_call_count = 0;
+
+static void add_call(FIXTURE_CALL_TYPE fixture_call_type)
+{
+    actual_calls[actual_call_count++] = fixture_call_type;
+}
+
+static void verify_expected_calls(FIXTURE_CALL_TYPE* expected_calls, int expected_call_count)
+{
+    CTEST_ASSERT_ARE_EQUAL(int, expected_call_count, actual_call_count);
+
+    for (int i = 0; i < expected_call_count; i++)
+    {
+        CTEST_ASSERT_ARE_EQUAL(FIXTURE_CALL_TYPE, expected_calls[i], actual_calls[i]);
+    }
+}
+
+static void suite_initialize_custom_fixture_1(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1);
+}
+
+static void suite_initialize_custom_fixture_2(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2);
+}
+
+static void suite_cleanup_custom_fixture_1(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_SUITE_CLEANUP_1);
+}
+
+static void suite_cleanup_custom_fixture_2(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_SUITE_CLEANUP_2);
+}
+
+static void function_initialize_custom_fixture_1(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1);
+}
+
+static void function_initialize_custom_fixture_2(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2);
+}
+
+static void function_cleanup_custom_fixture_1(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1);
+}
+
+static void function_cleanup_custom_fixture_2(void)
+{
+    add_call(FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2);
+}
+
+CTEST_SUITE_INITIALIZE(a, suite_initialize_custom_fixture_1, suite_initialize_custom_fixture_2)
+{
+    FIXTURE_CALL_TYPE expected_calls[] = { FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1, FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2 };
+    verify_expected_calls(expected_calls, MU_COUNT_ARRAY_ITEMS(expected_calls));
+    add_call(FIXTURE_CALL_USER_SUITE_INITIALIZE);
+}
+
+CTEST_SUITE_CLEANUP(b, suite_cleanup_custom_fixture_1, suite_cleanup_custom_fixture_2)
+{
+    FIXTURE_CALL_TYPE expected_calls[] = { 
+        FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1, FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2,
+        FIXTURE_CALL_USER_SUITE_INITIALIZE,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+        FIXTURE_CALL_USER_FUNCTION_CLEANUP,
+        FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1, FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+        FIXTURE_CALL_USER_FUNCTION_CLEANUP,
+        FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1, FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2,
+    };
+    verify_expected_calls(expected_calls, MU_COUNT_ARRAY_ITEMS(expected_calls));
+    add_call(FIXTURE_CALL_USER_SUITE_CLEANUP);
+}
+
+CTEST_FUNCTION_INITIALIZE(c, function_initialize_custom_fixture_1, function_initialize_custom_fixture_2)
+{
+    add_call(FIXTURE_CALL_USER_FUNCTION_INITIALIZE);
+}
+
+CTEST_FUNCTION_CLEANUP(d, function_cleanup_custom_fixture_1, function_cleanup_custom_fixture_2)
+{
+    add_call(FIXTURE_CALL_USER_FUNCTION_CLEANUP);
+}
+
+CTEST_FUNCTION(ctest_function_initialize_and_cleanuip_custom_fixtures_gets_executed)
+{
+    // arrange
+
+    // assert
+    FIXTURE_CALL_TYPE expected_calls[] = {
+    FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1, FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2,
+        FIXTURE_CALL_USER_SUITE_INITIALIZE,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+        FIXTURE_CALL_USER_FUNCTION_CLEANUP,
+        FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1, FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+    };
+    verify_expected_calls(expected_calls, MU_COUNT_ARRAY_ITEMS(expected_calls));
+}
+
+CTEST_FUNCTION(ctest_function_cleanup_custom_fixture_gets_executed)
+{
+    // arrange
+    // act is done by the virtue of using the hooks
+
+    // assert
+    FIXTURE_CALL_TYPE expected_calls[] = { 
+    FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1, FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2,
+        FIXTURE_CALL_USER_SUITE_INITIALIZE,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+    };
+    verify_expected_calls(expected_calls, MU_COUNT_ARRAY_ITEMS(expected_calls));
+}
+
+CTEST_END_TEST_SUITE(ctest_multiple_custom_fixtures_ut)
+
+// this function exists so that we can check from the main whether all calls really happened 
+// and they happened in the order that we wanted
+int ctest_multiple_custom_fixtures_test_succeeded(void)
+{
+    int result;
+
+    FIXTURE_CALL_TYPE expected_calls[] = {
+        FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_1, FIXTURE_CALL_CUSTOM_SUITE_INITIALIZE_2,
+        FIXTURE_CALL_USER_SUITE_INITIALIZE,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+        FIXTURE_CALL_USER_FUNCTION_CLEANUP,
+        FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1, FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2,
+        FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_1, FIXTURE_CALL_CUSTOM_FUNCTION_INITIALIZE_2,
+        FIXTURE_CALL_USER_FUNCTION_INITIALIZE,
+        FIXTURE_CALL_USER_FUNCTION_CLEANUP,
+        FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_1, FIXTURE_CALL_CUSTOM_FUNCTION_CLEANUP_2,
+        FIXTURE_CALL_USER_SUITE_CLEANUP,
+        FIXTURE_CALL_CUSTOM_SUITE_CLEANUP_1, FIXTURE_CALL_CUSTOM_SUITE_CLEANUP_2,
+    };
+
+    int expected_call_count = MU_COUNT_ARRAY_ITEMS(expected_calls);
+    if (expected_call_count != actual_call_count)
+    {
+        (void)printf("expected_call_count=%d, actual_call_count=%d\r\n", expected_call_count, actual_call_count);
+        result = MU_FAILURE;
+    }
+    else
+    {
+        int i;
+
+        for (i = 0; i < expected_call_count; i++)
+        {
+            if (expected_calls[i] != actual_calls[i])
+            {
+                (void)printf("expected_calls[i]=%" PRI_MU_ENUM ", actual_calls[i]=%" PRI_MU_ENUM "\r\n", MU_ENUM_VALUE(FIXTURE_CALL_TYPE, expected_calls[i]), MU_ENUM_VALUE(FIXTURE_CALL_TYPE, actual_calls[i]));
+                break;
+            }
+        }
+
+        if (i < expected_call_count)
+        {
+            result = MU_FAILURE;
+        }
+        else
+        {
+            result = 0;
+        }
+    }
+
+    return result;
+}

--- a/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.c
+++ b/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.c
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#include <stdio.h>  // for printf
+
 #include "macro_utils/macro_utils.h"
 
 #include "ctest.h"

--- a/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.c
+++ b/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.c
@@ -3,7 +3,7 @@
 
 #include <stdio.h>  // for printf
 
-#include "macro_utils/macro_utils.h"
+#include "macro_utils/macro_utils.h" // IWYU pragma: keep
 
 #include "ctest.h"
 

--- a/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.h
+++ b/tests/ctest_custom_fixtures_ut/ctest_multiple_custom_fixtures_ut.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef CTEST_MULTIPLE_CUSTOM_FIXTURES_UT_H
+#define CTEST_MULTIPLE_CUSTOM_FIXTURES_UT_H
+
+int ctest_multiple_custom_fixtures_test_succeeded(void);
+
+#endif // CTEST_MULTIPLE_CUSTOM_FIXTURES_UT_H

--- a/tests/ctest_custom_fixtures_ut/ctest_one_custom_fixture_ut.c
+++ b/tests/ctest_custom_fixtures_ut/ctest_one_custom_fixture_ut.c
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#include <stdio.h>  // for printf
+
 #include "ctest.h"
 
 CTEST_BEGIN_TEST_SUITE(ctest_one_custom_fixture_ut)

--- a/tests/ctest_custom_fixtures_ut/ctest_one_custom_fixture_ut.c
+++ b/tests/ctest_custom_fixtures_ut/ctest_one_custom_fixture_ut.c
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "ctest.h"
+
+CTEST_BEGIN_TEST_SUITE(ctest_one_custom_fixture_ut)
+
+static int times_suite_initialize_called = 0;
+static int times_suite_cleanup_called = 0;
+static int times_function_initialize_called = 0;
+static int times_function_cleanup_called = 0;
+static int expected_times_function_initialize_called = 1;
+static int expected_times_function_cleanup_called = 0;
+
+static void suite_initialize_custom_fixture(void)
+{
+    times_suite_initialize_called++;
+}
+
+static void suite_cleanup_custom_fixture(void)
+{
+    times_suite_cleanup_called++;
+}
+
+static void function_initialize_custom_fixture(void)
+{
+    times_function_initialize_called++;
+}
+
+static void function_cleanup_custom_fixture(void)
+{
+    times_function_cleanup_called++;
+}
+
+CTEST_SUITE_INITIALIZE(a, suite_initialize_custom_fixture)
+{
+    // make sure that custom fixtures have already been called
+    CTEST_ASSERT_ARE_EQUAL(int, 1, times_suite_initialize_called);
+}
+
+CTEST_SUITE_CLEANUP(b, suite_cleanup_custom_fixture)
+{
+    // make sure that the cleanup fixture was not yet called
+    CTEST_ASSERT_ARE_EQUAL(int, 0, times_suite_cleanup_called);
+}
+
+CTEST_FUNCTION_INITIALIZE(c, function_initialize_custom_fixture)
+{
+    // check that the function initialize custom fixture was already called by the time we got here
+    CTEST_ASSERT_ARE_EQUAL(int, expected_times_function_initialize_called, times_function_initialize_called);
+    expected_times_function_initialize_called++;
+}
+
+CTEST_FUNCTION_CLEANUP(d, function_cleanup_custom_fixture)
+{
+    // check that the function initialize custom fixture was not yet called by the time we got here
+    CTEST_ASSERT_ARE_EQUAL(int, expected_times_function_cleanup_called, times_function_cleanup_called);
+    expected_times_function_cleanup_called++;
+}
+
+CTEST_FUNCTION(ctest_function_initialize_and_cleanuip_custom_fixtures_gets_executed)
+{
+    // arrange
+
+    // assert
+    // 2 test functions have been executed at this point, so the variable was incremented twice 
+    CTEST_ASSERT_ARE_EQUAL(int, 2, times_function_initialize_called);
+    // 1 cleanup has been executed by this time
+    CTEST_ASSERT_ARE_EQUAL(int, 1, times_function_cleanup_called);
+}
+
+CTEST_FUNCTION(ctest_function_cleanup_custom_fixture_gets_executed)
+{
+    // arrange
+    // act is done by the virtue of using the hooks
+
+    // assert
+    // 1 test functions have been executed at this point, so the variable was incremented twice 
+    CTEST_ASSERT_ARE_EQUAL(int, 1, times_function_initialize_called);
+    // 0 cleanup has been executed by this time
+    CTEST_ASSERT_ARE_EQUAL(int, 0, times_function_cleanup_called);
+}
+
+CTEST_END_TEST_SUITE(ctest_one_custom_fixture_ut)
+
+// this function exists so that we can check from the main whether teh final suite cleanup call really happened
+int ctest_one_custom_fixture_test_succeeded(void)
+{
+    int result;
+
+    if (times_suite_cleanup_called != 1)
+    {
+        (void)printf("times_suite_cleanup_called should be 1\r\n");
+        result = MU_FAILURE;
+    }
+    else
+    {
+        result = 0;
+    }
+
+    return result;
+}

--- a/tests/ctest_custom_fixtures_ut/ctest_one_custom_fixture_ut.h
+++ b/tests/ctest_custom_fixtures_ut/ctest_one_custom_fixture_ut.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef CTEST_ONE_CUSTOM_FIXTURE_UT_H
+#define CTEST_ONE_CUSTOM_FIXTURE_UT_H
+
+int ctest_one_custom_fixture_test_succeeded(void);
+
+#endif // CTEST_ONE_CUSTOM_FIXTURE_UT_H

--- a/tests/ctest_custom_fixtures_ut/main.c
+++ b/tests/ctest_custom_fixtures_ut/main.c
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <stddef.h>  // for size_t
+#include "ctest.h"
+
+#include "ctest_one_custom_fixture_ut.h"
+#include "ctest_multiple_custom_fixtures_ut.h"
+
+int main()
+{
+    size_t failedTests = 0;
+    CTEST_RUN_TEST_SUITE(ctest_one_custom_fixture_ut);
+    if (ctest_one_custom_fixture_test_succeeded() != 0)
+    {
+        // if the final validation of how we called the fixtures has failed it means at least one test is failed
+        failedTests++;
+    }
+    CTEST_RUN_TEST_SUITE(ctest_multiple_custom_fixtures_ut);
+    if (ctest_multiple_custom_fixtures_test_succeeded() != 0)
+    {
+        // if the final validation of how we called the fixtures has failed it means at least one test is failed
+        failedTests++;
+    }
+    return failedTests;
+}

--- a/tests/ctest_macro_hooks_ut/CMakeLists.txt
+++ b/tests/ctest_macro_hooks_ut/CMakeLists.txt
@@ -21,5 +21,5 @@ set_target_properties(ctest_macro_hooks_ut
 target_link_libraries(ctest_macro_hooks_ut ctest)
 
 if(${run_unittests})
-	add_test(NAME ctest_macro_hooks_ut COMMAND ctest_macro_hooks_ut)
+    add_test(NAME ctest_macro_hooks_ut COMMAND ctest_macro_hooks_ut)
 endif()

--- a/tests/ctest_ut/CMakeLists.txt
+++ b/tests/ctest_ut/CMakeLists.txt
@@ -45,5 +45,5 @@ set_target_properties(ctest_ut
 target_link_libraries(ctest_ut ctest)
 
 if(${run_unittests})
-	add_test(NAME ctest_ut COMMAND ctest_ut)
+    add_test(NAME ctest_ut COMMAND ctest_ut)
 endif()


### PR DESCRIPTION
Add custom fixtures for suite init/cleanup and function init/cleanup in order to be able to use them for serializing the tests by the use of a mutex in test runner switcher